### PR TITLE
Dot Joins Work in Both Directions now

### DIFF
--- a/dist/ForgeExprEvaluator.d.ts
+++ b/dist/ForgeExprEvaluator.d.ts
@@ -16,7 +16,6 @@ export declare class ForgeExprEvaluator extends AbstractParseTreeVisitor<EvalRes
     private instanceData;
     private predicates;
     private environmentStack;
-    private quantDeclEnvironmentStack;
     constructor(datum: DatumParsed, instanceIndex: number, predicates: Predicate[]);
     private isPredicateName;
     private getPredicate;

--- a/dist/ForgeExprEvaluator.js
+++ b/dist/ForgeExprEvaluator.js
@@ -941,14 +941,31 @@ class ForgeExprEvaluator extends AbstractParseTreeVisitor_1.AbstractParseTreeVis
                     results = afterDotExpr
                         .filter((tuple) => tuple[0] === joinValue)
                         .map((tuple) => tuple.slice(1));
+                    if (results.some((tuple) => tuple.length === 0)) {
+                        throw new Error('Join would create a relation of arity 0');
+                    }
                     return results;
                 }
                 else {
-                    throw new Error('Expected the expression after the dot to be a tuple array (relation)');
+                    throw new Error('One of the relations being joined must have arity 1');
                 }
             }
-            else {
-                throw new Error('Expected the expression before the dot to be a single value (atom)');
+            else if (isTupleArray(afterDotExpr) &&
+                afterDotExpr.length === 1 &&
+                afterDotExpr[0].length === 1) {
+                const joinValue = afterDotExpr[0][0];
+                if (isTupleArray(beforeDotExpr)) {
+                    results = beforeDotExpr
+                        .filter((tuple) => tuple[tuple.length - 1] === joinValue)
+                        .map((tuple) => tuple.slice(0, tuple.length - 1));
+                    if (results.some((tuple) => tuple.length === 0)) {
+                        throw new Error('Join would create a relation of arity 0');
+                    }
+                    return results;
+                }
+                else {
+                    throw new Error('One of the relations being joined must have arity 1');
+                }
             }
         }
         if (ctx.LEFT_SQUARE_TOK()) {

--- a/dist/ForgeExprEvaluator.js
+++ b/dist/ForgeExprEvaluator.js
@@ -201,6 +201,7 @@ class ForgeExprEvaluator extends AbstractParseTreeVisitor_1.AbstractParseTreeVis
                 throw new Error('Expected the quantifier to have a quantDeclList!');
             }
             const varQuantifiedSets = this.getQuantDeclListValues(ctx.quantDeclList());
+            const isDisjoint = ctx.DISJ_TOK() !== undefined;
             // NOTE: this doesn't support the situation in which blockOrBar is a block
             // yet
             const blockOrBar = ctx.blockOrBar();
@@ -223,6 +224,21 @@ class ForgeExprEvaluator extends AbstractParseTreeVisitor_1.AbstractParseTreeVis
             let foundFalse = false;
             for (let i = 0; i < product.length; i++) {
                 const tuple = product[i];
+                if (isDisjoint) {
+                    // the elements of the tuple must be different
+                    let tupleDisjoint = true;
+                    const seen = new Set();
+                    for (const val of tuple) {
+                        if (seen.has(val)) {
+                            tupleDisjoint = false;
+                            break;
+                        }
+                        seen.add(val);
+                    }
+                    if (!tupleDisjoint) {
+                        continue;
+                    }
+                }
                 const quantDeclEnv = {};
                 for (let j = 0; j < varNames.length; j++) {
                     const varName = varNames[j];

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -267,10 +267,80 @@ export class ForgeExprEvaluator
       throw new Error('**NOT IMPLEMENTING FOR NOW** Bind Expression');
     }
     if (ctx.quant()) {
-      results = [];
-      results.push([
-        '**UNIMPLEMENTED** Quantified Expression (`all`, `some`, `no`, etc.)'
-      ]);
+      // results = [];
+      // results.push([
+      //   '**UNIMPLEMENTED** Quantified Expression (`all`, `some`, `no`, etc.)'
+      // ]);
+
+      // TODO: add support for disj here
+      if (ctx.quantDeclList() === undefined) {
+        throw new Error('Expected the quantifier to have a quantDeclList!');
+      }
+      const varQuantifiedSets = this.getQuantDeclListValues(ctx.quantDeclList()!);
+
+      // NOTE: this doesn't support the situation in which blockOrBar is a block
+      // yet
+      const blockOrBar = ctx.blockOrBar();
+      if (blockOrBar === undefined) {
+        throw new Error('expected to quantify over something!');
+      }
+      if (blockOrBar.BAR_TOK() === undefined || blockOrBar.expr() === undefined) {
+        throw new Error('Expected the quantifier to have a bar followed by an expr!');
+      }
+      const barExpr = blockOrBar.expr()!;
+      const varNames: string[] = [];
+      const quantifiedSets: Tuple[][] = [];
+      for (const varName in varQuantifiedSets) {
+        varNames.push(varName);
+        quantifiedSets.push(varQuantifiedSets[varName]);
+      }
+      const product: Tuple[] = getCombinations(quantifiedSets);
+
+      const result: Tuple[] = [];
+
+      let foundTrue = false;
+      let foundFalse = false;
+
+      for (let i = 0; i < product.length; i++) {
+        const tuple = product[i];
+        const quantDeclEnv: Environment = {};
+        for (let j = 0; j < varNames.length; j++) {
+          const varName = varNames[j];
+          const varValue = tuple[j];
+          quantDeclEnv[varName] = varValue;
+        }
+
+        this.quantDeclEnvironmentStack.push(quantDeclEnv);
+
+        // now, we want to evaluate the barExpr
+        const barExprValue = this.visit(barExpr);
+        if (getBooleanValue(barExprValue)) { // will error if not boolean val, which we want
+          result.push(tuple);
+          foundTrue = true;
+        } else {
+          foundFalse = true;
+        }
+
+        this.quantDeclEnvironmentStack.pop();
+      }
+
+      if (ctx.quant()!.ALL_TOK()) {
+        return !foundFalse ? TRUE_LITERAL : FALSE_LITERAL;
+      } else if (ctx.quant()!.NO_TOK()) {
+        return !foundTrue ? TRUE_LITERAL : FALSE_LITERAL;
+      } else if (ctx.quant()!.mult()) {
+        const multExpr = ctx.quant()!.mult()!;
+        if (multExpr.LONE_TOK()) {
+          return result.length <= 1 ? TRUE_LITERAL : FALSE_LITERAL;
+        } else if (multExpr.SOME_TOK()) {
+          return foundTrue ? TRUE_LITERAL : FALSE_LITERAL;
+        } else if (multExpr.ONE_TOK()) {
+          result.length === 1 ? TRUE_LITERAL : FALSE_LITERAL;
+        } else if (multExpr.TWO_TOK()) {
+          throw new Error('**NOT IMPLEMENTING FOR NOW** Two (`two`)');
+        }
+      }
+      // TODO: don't have support for SUM_TOK yet
     }
 
     // TODO: fix this!

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -1090,16 +1090,35 @@ export class ForgeExprEvaluator
           results = afterDotExpr
             .filter((tuple) => tuple[0] === joinValue)
             .map((tuple) => tuple.slice(1));
+          if (results.some((tuple) => tuple.length === 0)) {
+            throw new Error('Join would create a relation of arity 0');
+          }
           return results;
         } else {
           throw new Error(
-            'Expected the expression after the dot to be a tuple array (relation)'
+            'One of the relations being joined must have arity 1'
           );
         }
-      } else {
-        throw new Error(
-          'Expected the expression before the dot to be a single value (atom)'
-        );
+      } else if (
+        isTupleArray(afterDotExpr) &&
+        afterDotExpr.length === 1 &&
+        afterDotExpr[0].length === 1
+      ) {
+        const joinValue = afterDotExpr[0][0];
+
+        if (isTupleArray(beforeDotExpr)) {
+          results = beforeDotExpr
+            .filter((tuple) => tuple[tuple.length - 1] === joinValue)
+            .map((tuple) => tuple.slice(0, tuple.length - 1));
+          if (results.some((tuple) => tuple.length === 0)) {
+            throw new Error('Join would create a relation of arity 0');
+          }
+          return results;
+        } else {
+          throw new Error(
+            'One of the relations being joined must have arity 1'
+          );
+        }
       }
     }
 

--- a/src/ForgeExprEvaluator.ts
+++ b/src/ForgeExprEvaluator.ts
@@ -278,6 +278,8 @@ export class ForgeExprEvaluator
       }
       const varQuantifiedSets = this.getQuantDeclListValues(ctx.quantDeclList()!);
 
+      const isDisjoint = ctx.DISJ_TOK() !== undefined;
+
       // NOTE: this doesn't support the situation in which blockOrBar is a block
       // yet
       const blockOrBar = ctx.blockOrBar();
@@ -303,6 +305,21 @@ export class ForgeExprEvaluator
 
       for (let i = 0; i < product.length; i++) {
         const tuple = product[i];
+        if (isDisjoint) {
+          // the elements of the tuple must be different
+          let tupleDisjoint = true;
+          const seen = new Set();
+          for (const val of tuple) {
+            if (seen.has(val)) {
+              tupleDisjoint = false;
+              break;
+            }
+            seen.add(val);
+          }
+          if (!tupleDisjoint) {
+            continue;
+          }
+        }
         const quantDeclEnv: Environment = {};
         for (let j = 0; j < varNames.length; j++) {
           const varName = varNames[j];

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -217,5 +217,17 @@ describe("forge-expr-evaluator", () => {
     const result = evaluatorUtil.evaluateExpression(expr, instanceIdx);
 
     expect(result).toEqual("#t");
-  })
+  });
+
+  it("can evaluate chained dot joins", () => {
+    const datum: DatumParsed = tttDatum;
+    const sourceCode = getCodeFromDatum(datum);
+
+    const evaluatorUtil = new ForgeExprEvaluatorUtil(datum, sourceCode);
+    const expr = "Game.next.Board1";
+    const instanceIdx = 0;
+    const result = evaluatorUtil.evaluateExpression(expr, instanceIdx);
+
+    expect(result).toEqual([["Board0"]]);
+  });
 });

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -188,4 +188,20 @@ describe("forge-expr-evaluator", () => {
 
     expect(result).toEqual("#t");
   });
+
+  it("can perform truthy quantifications when specifying disjoint", () => {
+    const datum: DatumParsed = tttDatum;
+    const sourceCode = getCodeFromDatum(datum);
+
+    const evaluatorUtil = new ForgeExprEvaluatorUtil(datum, sourceCode);
+    const instanceIdx = 0;
+
+    const expr1 = "all disj i, j : Int | { not i = j }";
+    const result1 = evaluatorUtil.evaluateExpression(expr1, instanceIdx);
+    expect(result1).toEqual("#t");
+
+    const expr2 = "some disj i, j : Int | { i = j }";
+    const result2 = evaluatorUtil.evaluateExpression(expr2, instanceIdx);
+    expect(result2).toEqual("#f");
+  });
 });

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -82,7 +82,6 @@ describe("forge-expr-evaluator", () => {
     ]);
   });
 
-
   it("can evaluate a set comprehension", () => {
     const datum: DatumParsed = tttDatum;
     const sourceCode = getCodeFromDatum(datum);
@@ -102,7 +101,7 @@ describe("forge-expr-evaluator", () => {
     ]);
   });
 
-  skip("can evaluate cardinality on the result of a set comprehension", () => {
+  it("can evaluate cardinality on the result of a set comprehension", () => {
     const datum: DatumParsed = tttDatum;
     const sourceCode = getCodeFromDatum(datum);
 
@@ -137,7 +136,6 @@ describe("forge-expr-evaluator", () => {
 
     expect(result).toEqual([["X0", "O0", "X0"]]);
   });
-
 
   it("can evaluate basic inter and intra-sig relations", () => {
     const datum: DatumParsed = interSigDatum;
@@ -177,5 +175,17 @@ describe("forge-expr-evaluator", () => {
     const result = evaluatorUtil.evaluateExpression(expr, instanceIdx);
 
     expect(result).toEqual("#t");
-  })
+  });
+
+  it("can quantify in a truthy way if there is a block after the bar", () => {
+    const datum: DatumParsed = tttDatum;
+    const sourceCode = getCodeFromDatum(datum);
+
+    const evaluatorUtil = new ForgeExprEvaluatorUtil(datum, sourceCode);
+    const expr = "some i : Int | { i < 4 \n i > 2}";
+    const instanceIdx = 0;
+    const result = evaluatorUtil.evaluateExpression(expr, instanceIdx);
+
+    expect(result).toEqual("#t");
+  });
 });

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -166,4 +166,16 @@ describe("forge-expr-evaluator", () => {
 
     expect(result).toEqual([["A0"]]);
   });
+
+  it("can quantify in a truthy way", () => {
+    const datum: DatumParsed = tttDatum;
+    const sourceCode = getCodeFromDatum(datum);
+
+    const evaluatorUtil = new ForgeExprEvaluatorUtil(datum, sourceCode);
+    const expr = "some i : Int | i < 4";
+    const instanceIdx = 0;
+    const result = evaluatorUtil.evaluateExpression(expr, instanceIdx);
+
+    expect(result).toEqual("#t");
+  })
 });

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,4 +1,3 @@
-import { skip } from "node:test";
 import { ForgeExprEvaluatorUtil } from "../src";
 import { DatumParsed } from "../src/types";
 import tttDatum from "./examples/ttt-basic/datum.json";

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -204,4 +204,18 @@ describe("forge-expr-evaluator", () => {
     const result2 = evaluatorUtil.evaluateExpression(expr2, instanceIdx);
     expect(result2).toEqual("#f");
   });
+
+  it("can avoid variable shadowing issues across predicate args and quantified vars", () => {
+    const datum: DatumParsed = tttDatum;
+    const sourceCode = getCodeFromDatum(datum);
+
+    const evaluatorUtil = new ForgeExprEvaluatorUtil(datum, sourceCode);
+    // quantified x is shadowed by the x which is the argument to argPred1
+    // if shadowing doesn't work properly, this will return #f
+    const expr = "all x : Int | argPred1[3, 3]";
+    const instanceIdx = 0;
+    const result = evaluatorUtil.evaluateExpression(expr, instanceIdx);
+
+    expect(result).toEqual("#t");
+  })
 });


### PR DESCRIPTION
Dot joins were earlier only working in one direction (right-joining a value onto a relation). This PR adds support for the other direction as well.

* In the process, the issue with chained dot joins was also resolved: closes #12.